### PR TITLE
Feat

### DIFF
--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/member/entity/Member.java
@@ -22,7 +22,7 @@ import java.util.List;
 @NoArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements Comparable<Member>{
     @Column(unique = true)
     private String name;
     private String email;
@@ -39,4 +39,9 @@ public class Member extends BaseEntity {
     @JsonIgnore
     @Builder.Default
     private List<Room> rooms = new ArrayList<>();
+
+    @Override
+    public int compareTo(Member o) {
+        return name.compareTo(o.name);
+    }
 }

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
@@ -18,4 +18,13 @@ public class RoomTreeMap {
         members.add(member);
         roomTreeMap.put(localDateTime, members);
     }
+
+    public synchronized void deleteTreeMap(LocalDateTime localDateTime, Member member) {
+        TreeSet<Member> members = roomTreeMap.getOrDefault(localDateTime, new TreeSet<>());
+        members.remove(member);
+        roomTreeMap.put(localDateTime, members);
+        if (members.isEmpty()) {
+            roomTreeMap.remove(localDateTime);
+        }
+    }
 }

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
@@ -1,0 +1,22 @@
+package com.ll.moizatimecalculator.boundedContext.selectedTime.entity;
+
+import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import java.time.LocalDateTime;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+public class RoomTreeMap {
+    private final TreeMap<LocalDateTime, TreeSet<Member>> roomTreeMap = new TreeMap<>();
+
+    public TreeMap<LocalDateTime, TreeSet<Member>> getRoomTreeMap() {
+        return roomTreeMap;
+    }
+
+    public void setRoomTreeMapDateWithMember(LocalDateTime localDateTime, Member member) {
+        synchronized (this) {
+            TreeSet<Member> members = roomTreeMap.getOrDefault(localDateTime, new TreeSet<>());
+            members.add(member);
+            roomTreeMap.put(localDateTime, members);
+        }
+    }
+}

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMap.java
@@ -6,17 +6,16 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class RoomTreeMap {
+
     private final TreeMap<LocalDateTime, TreeSet<Member>> roomTreeMap = new TreeMap<>();
 
     public TreeMap<LocalDateTime, TreeSet<Member>> getRoomTreeMap() {
         return roomTreeMap;
     }
 
-    public void setRoomTreeMapDateWithMember(LocalDateTime localDateTime, Member member) {
-        synchronized (this) {
-            TreeSet<Member> members = roomTreeMap.getOrDefault(localDateTime, new TreeSet<>());
-            members.add(member);
-            roomTreeMap.put(localDateTime, members);
-        }
+    public synchronized void setRoomTreeMapDateWithMember(LocalDateTime localDateTime, Member member) {
+        TreeSet<Member> members = roomTreeMap.getOrDefault(localDateTime, new TreeSet<>());
+        members.add(member);
+        roomTreeMap.put(localDateTime, members);
     }
 }

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
@@ -32,7 +32,7 @@ public class RoomTreeMapService {
         return roomDataMap.computeIfAbsent(roomId, key -> new RoomTreeMap());
     }
 
-    public synchronized void setRoomTreeMap(Long roomId, LocalDate localDate, LocalTime localTime,
+    public void setRoomTreeMap(Long roomId, LocalDate localDate, LocalTime localTime,
             Member member) {
         LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
 
@@ -40,7 +40,7 @@ public class RoomTreeMapService {
         roomTreeMap.setRoomTreeMapDateWithMember(localDateTime, member);
     }
 
-    public synchronized List<TimeRangeWithMember> findOverlappingTimeRanges(Long roomId) {
+    public List<TimeRangeWithMember> findOverlappingTimeRanges(Long roomId) {
         RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
 
         List<Entry<LocalDateTime, TreeSet<Member>>> entries = getSortedEntries(roomTreeMap);

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
@@ -1,13 +1,18 @@
 package com.ll.moizatimecalculator.boundedContext.selectedTime.service;
 
 import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import com.ll.moizatimecalculator.boundedContext.room.entity.Room;
 import com.ll.moizatimecalculator.boundedContext.room.repository.EnterRoomRepository;
 import com.ll.moizatimecalculator.boundedContext.room.service.RoomService;
 import com.ll.moizatimecalculator.boundedContext.selectedTime.entity.RoomTreeMap;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,4 +39,12 @@ public class RoomTreeMapService {
         RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
         roomTreeMap.setRoomTreeMapDateWithMember(localDateTime, member);
     }
+
+    public void delete(Long roomId, LocalDate localDate, LocalTime localTime,
+            Member member) {
+        RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
+        LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+        roomTreeMap.deleteTreeMap(localDateTime, member);
+    }
+
 }

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
@@ -1,0 +1,37 @@
+package com.ll.moizatimecalculator.boundedContext.selectedTime.service;
+
+import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import com.ll.moizatimecalculator.boundedContext.room.repository.EnterRoomRepository;
+import com.ll.moizatimecalculator.boundedContext.room.service.RoomService;
+import com.ll.moizatimecalculator.boundedContext.selectedTime.entity.RoomTreeMap;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoomTreeMapService {
+
+    @Autowired
+    RoomService roomService;
+
+    @Autowired
+    EnterRoomRepository enterRoomRepository;
+
+    private final Map<Long, RoomTreeMap> roomDataMap = new ConcurrentHashMap<>();
+
+    public RoomTreeMap getRoomTreeMap(Long roomId) {
+        return roomDataMap.computeIfAbsent(roomId, key -> new RoomTreeMap());
+    }
+
+    public synchronized void setRoomTreeMap(Long roomId, LocalDate localDate, LocalTime localTime,
+            Member member) {
+        LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+
+        RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
+        roomTreeMap.setRoomTreeMapDateWithMember(localDateTime, member);
+    }
+}

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapService.java
@@ -40,6 +40,14 @@ public class RoomTreeMapService {
         roomTreeMap.setRoomTreeMapDateWithMember(localDateTime, member);
     }
 
+    public synchronized List<TimeRangeWithMember> findOverlappingTimeRanges(Long roomId) {
+        RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
+
+        List<Entry<LocalDateTime, TreeSet<Member>>> entries = getSortedEntries(roomTreeMap);
+
+        return getFindTOP10(roomId, entries);
+    }
+
     public void delete(Long roomId, LocalDate localDate, LocalTime localTime,
             Member member) {
         RoomTreeMap roomTreeMap = getRoomTreeMap(roomId);
@@ -47,4 +55,50 @@ public class RoomTreeMapService {
         roomTreeMap.deleteTreeMap(localDateTime, member);
     }
 
+    private List<TimeRangeWithMember> getFindTOP10(Long roomId,
+            List<Entry<LocalDateTime, TreeSet<Member>>> entries) {
+        List<TimeRangeWithMember> list = new ArrayList<>();
+        Room room = roomService.getRoom(roomId);
+        List<Member> members = enterRoomRepository.findMembersByRoom(room);
+
+        for (Entry<LocalDateTime, TreeSet<Member>> entry : entries) {
+            List<Member> contain = new ArrayList<>(entry.getValue());
+            List<Member> noContain = geNoCinTaiontMembers(members, contain);
+
+            list.add(new TimeRangeWithMember(entry.getKey().toLocalDate(),
+                    entry.getKey().toLocalTime(),
+                    entry.getKey().toLocalTime().plusHours(room.getMeetingDuration().getHour())
+                            .plusMinutes(room.getMeetingDuration().getMinute()), contain,
+                    noContain));
+
+            if (list.size() == 10) {
+                break;
+            }
+        }
+        return list;
+    }
+
+    private List<Entry<LocalDateTime, TreeSet<Member>>> getSortedEntries(RoomTreeMap roomTreeMap) {
+        List<Entry<LocalDateTime, TreeSet<Member>>> entries = new ArrayList<>(
+                roomTreeMap.getRoomTreeMap().entrySet());
+
+        entries.sort((o1, o2) -> {
+            if (o1.getValue().size() == o2.getValue().size()) {
+                return o1.getKey().compareTo(o2.getKey());
+            }
+            return o2.getValue().size() - o1.getValue().size();
+        });
+        return entries;
+    }
+
+    private List<Member> geNoCinTaiontMembers(List<Member> members, List<Member> contain) {
+        List<Member> noContain = new ArrayList<>();
+
+        for (Member m : members) {
+            if (!contain.contains(m)) {
+                noContain.add(m);
+            }
+        }
+        return noContain;
+    }
 }

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeService.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -75,30 +74,8 @@ public class SelectedTimeService {
         }
     }
 
-    @Cacheable(value = "overlappingTimeRangesCache", key = "#room.id")
     public List<TimeRangeWithMember> findOverlappingTimeRanges(Room room) {
-        List<TimeRangeWithMember> timeRangeWithMembers = new LinkedList<>();
-
-        LocalDate curDate = room.getAvailableStartDay();
-
-        while (!curDate.isAfter(room.getAvailableEndDay())) {
-            List<TimeRangeWithMember> getTimeRangesWhitRoomAndDay = findOverlappingTimeRanges(room,
-                    curDate);
-            timeRangeWithMembers.addAll(getTimeRangesWhitRoomAndDay);
-
-            curDate = curDate.plusDays(ONE_DAY);
-        }
-
-        if (!timeRangeWithMembers.isEmpty()) {
-            Collections.sort(timeRangeWithMembers);
-        }
-
-        if (timeRangeWithMembers.size() > MEMBER_MAX_SIZE) {
-            timeRangeWithMembers = new ArrayList<>(
-                    timeRangeWithMembers.subList(0, MEMBER_MAX_SIZE));
-        }
-
-        return timeRangeWithMembers;
+        return roomTreeMapService.findOverlappingTimeRanges(room.getId());
     }
 
     @CacheEvict(value = "overlappingTimeRangesCache", key = "#room.id")

--- a/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeService.java
+++ b/src/main/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeService.java
@@ -6,6 +6,14 @@ import com.ll.moizatimecalculator.boundedContext.room.entity.Room;
 import com.ll.moizatimecalculator.boundedContext.room.repository.EnterRoomRepository;
 import com.ll.moizatimecalculator.boundedContext.selectedTime.entity.SelectedTime;
 import com.ll.moizatimecalculator.boundedContext.selectedTime.repository.SelectedTimeRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -13,11 +21,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.*;
-import java.util.stream.Collectors;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
@@ -29,6 +32,9 @@ public class SelectedTimeService {
     private final SelectedTimeRepository selectedTimeRepository;
 
     private final EnterRoomRepository enterRoomRepository;
+
+    private final RoomTreeMapService roomTreeMapService;
+
     private static final int MEMBER_MAX_SIZE = 10;
     private static final int MIN_PARTICIPATION_MEMBER = 1;
     private static final int THIRTY_MIN = 30;
@@ -47,9 +53,26 @@ public class SelectedTimeService {
                 .endTime(endTime)
                 .enterRoom(enterRoom)
                 .build();
+        setRoomTreeMap(day, startTime, endTime, enterRoom);
 
         enterRoom.getSelectedTimes().add(selectedTime);
         return selectedTimeRepository.save(selectedTime);
+    }
+
+    private void setRoomTreeMap(LocalDate day,
+            LocalTime startTime,
+            LocalTime endTime,
+            EnterRoom enterRoom) {
+        LocalTime meetingDuration = enterRoom.getRoom().getMeetingDuration();
+        LocalTime curTime = startTime.plusHours(meetingDuration.getHour())
+                .plusMinutes(meetingDuration.getMinute());
+
+        while (!curTime.isAfter(endTime)) {
+            roomTreeMapService.setRoomTreeMap(enterRoom.getRoom().getId(), day, startTime,
+                    enterRoom.getMember());
+            curTime = curTime.plusMinutes(30);
+            startTime = startTime.plusMinutes(30);
+        }
     }
 
     @Cacheable(value = "overlappingTimeRangesCache", key = "#room.id")
@@ -59,24 +82,27 @@ public class SelectedTimeService {
         LocalDate curDate = room.getAvailableStartDay();
 
         while (!curDate.isAfter(room.getAvailableEndDay())) {
-            List<TimeRangeWithMember> getTimeRangesWhitRoomAndDay = findOverlappingTimeRanges(room, curDate);
+            List<TimeRangeWithMember> getTimeRangesWhitRoomAndDay = findOverlappingTimeRanges(room,
+                    curDate);
             timeRangeWithMembers.addAll(getTimeRangesWhitRoomAndDay);
 
             curDate = curDate.plusDays(ONE_DAY);
         }
 
-        if (!timeRangeWithMembers.isEmpty())
+        if (!timeRangeWithMembers.isEmpty()) {
             Collections.sort(timeRangeWithMembers);
+        }
 
         if (timeRangeWithMembers.size() > MEMBER_MAX_SIZE) {
-            timeRangeWithMembers = new ArrayList<>(timeRangeWithMembers.subList(0, MEMBER_MAX_SIZE));
+            timeRangeWithMembers = new ArrayList<>(
+                    timeRangeWithMembers.subList(0, MEMBER_MAX_SIZE));
         }
 
         return timeRangeWithMembers;
     }
 
     @CacheEvict(value = "overlappingTimeRangesCache", key = "#room.id")
-    public void refreshCache(Room room){
+    public void refreshCache(Room room) {
         // 캐시 지우기 위한 메서드
     }
 
@@ -100,14 +126,17 @@ public class SelectedTimeService {
                 .plusMinutes(meetingDuration.getMinute());
 
         while (endTime.isBefore(room.getAvailableEndTime())) {
-            List<Member> participationMembers = getParticipationMembers(selectedTimeList, meetingDuration,
+            List<Member> participationMembers = getParticipationMembers(selectedTimeList,
+                    meetingDuration,
                     startTime, endTime);
 
-            List<Member> nonParticipationMembers = getNonParticipationMembers(room, participationMembers);
+            List<Member> nonParticipationMembers = getNonParticipationMembers(room,
+                    participationMembers);
 
             if (participationMembers.size() >= MIN_PARTICIPATION_MEMBER) {
                 overlappingRanges.add(
-                        new TimeRangeWithMember(date, startTime, endTime, participationMembers, nonParticipationMembers));
+                        new TimeRangeWithMember(date, startTime, endTime, participationMembers,
+                                nonParticipationMembers));
             }
 
             startTime = startTime.plusMinutes(THIRTY_MIN);
@@ -129,7 +158,8 @@ public class SelectedTimeService {
             LocalTime startTime,
             LocalTime endTime) {
         return selectedTimeList.stream()
-                .filter(selectedTime -> selectedTime.isParticipation(meetingDuration, startTime, endTime))
+                .filter(selectedTime -> selectedTime.isParticipation(meetingDuration, startTime,
+                        endTime))
                 .map(SelectedTime::getEnterRoom)
                 .map(EnterRoom::getMember)
                 .distinct()

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMapTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/entity/RoomTreeMapTest.java
@@ -1,0 +1,30 @@
+package com.ll.moizatimecalculator.boundedContext.selectedTime.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class RoomTreeMapTest {
+
+    @Test
+    void RoomTreeMapTest() {
+
+        Member member = Member.builder().name("user1").email("user1@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+
+        Member member2 = Member.builder().name("user2").email("user2@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+
+        RoomTreeMap rtm = new RoomTreeMap();
+        rtm.setRoomTreeMapDateWithMember(LocalDateTime.now(), member2);
+        rtm.setRoomTreeMapDateWithMember(LocalDateTime.now(), member);
+        System.out.println(rtm.getRoomTreeMap());
+    }
+}

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceTest.java
@@ -83,6 +83,25 @@ class RoomTreeMapServiceTest {
             }
             System.out.println();
         }
+
+        roomTreeMapService.delete(roomId, LocalDate.now().plusDays(1), LocalTime.of(0, 0, 0), member3);
+
+        List<TimeRangeWithMember> overlappingRanges2 = roomTreeMapService.findOverlappingTimeRanges(
+                roomId);
+
+        for (TimeRangeWithMember t : overlappingRanges2) {
+            System.out.println(t.date + " | " + t.start + "~" + t.end);
+            System.out.print("참가자 : ");
+            for (Member m : t.getParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+            System.out.print("불참자 : ");
+            for (Member m : t.getNonParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+        }
     }
 
     @BeforeEach

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceTest.java
@@ -1,0 +1,135 @@
+package com.ll.moizatimecalculator.boundedContext.selectedTime.service;
+
+import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import com.ll.moizatimecalculator.boundedContext.member.repository.MemberRepository;
+import com.ll.moizatimecalculator.boundedContext.room.entity.EnterRoom;
+import com.ll.moizatimecalculator.boundedContext.room.entity.Room;
+import com.ll.moizatimecalculator.boundedContext.room.repository.EnterRoomRepository;
+import com.ll.moizatimecalculator.boundedContext.room.repository.RoomRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@EnableCaching
+@ActiveProfiles("test")
+@Transactional
+class RoomTreeMapServiceTest {
+
+    @Autowired
+    RoomTreeMapService roomTreeMapService;
+    @Autowired
+    RoomRepository roomRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EnterRoomRepository enterRoomRepository;
+
+    Room room;
+    Member member1;
+    Member member2;
+    Member member3;
+
+    @Test
+    @DisplayName("삽입 및 삭제 테스트")
+    @Transactional
+    void RoomTreeMapServiceTest() {
+
+        long roomId = room.getId();
+
+        TreeMap<LocalDateTime, TreeSet<Member>> treeMap = roomTreeMapService.getRoomTreeMap(roomId)
+                .getRoomTreeMap();
+
+        System.out.println(treeMap);
+
+        roomTreeMapService.setRoomTreeMap(roomId, LocalDate.now().plusDays(3), LocalTime.of(0, 0, 0),
+                member1);
+        roomTreeMapService.setRoomTreeMap(roomId, LocalDate.now().plusDays(3), LocalTime.of(0, 0, 0),
+                member2);
+        roomTreeMapService.setRoomTreeMap(roomId, LocalDate.now().plusDays(3), LocalTime.of(0, 0, 0),
+                member3);
+        roomTreeMapService.setRoomTreeMap(roomId, LocalDate.now().plusDays(2), LocalTime.of(0, 0, 0),
+                member2);
+        roomTreeMapService.setRoomTreeMap(roomId, LocalDate.now().plusDays(1), LocalTime.of(0, 0, 0),
+                member3);
+
+        System.out.println(treeMap);
+
+        List<TimeRangeWithMember> overlappingRanges = roomTreeMapService.findOverlappingTimeRanges(
+                roomId);
+
+        for (TimeRangeWithMember t : overlappingRanges) {
+            System.out.println(t.date + " | " + t.start + "~" + t.end);
+            System.out.print("참가자 : ");
+            for (Member m : t.getParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+            System.out.print("불참자 : ");
+            for (Member m : t.getNonParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+        }
+    }
+
+    @BeforeEach
+    void init() {
+        member1 = Member.builder().name("user1").email("user1@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member1);
+        member2 = Member.builder().name("user2").email("user2@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member2);
+        member3 = Member.builder().name("user3").email("user3@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member3);
+
+        room = Room.builder()
+                .leader(member1)
+                .name("테스트1")
+                .description("description")
+                .availableStartDay(LocalDate.now().plusDays(5))
+                .availableEndDay(LocalDate.now().plusDays(7))
+                .availableStartTime(LocalTime.of(0, 0))
+                .availableEndTime(LocalTime.of(23, 0))
+                .meetingDuration(LocalTime.of(3, 0))
+                .deadLine(LocalDateTime.now().plusDays(2))
+                .accessCode(UUID.randomUUID().toString())
+                .build();
+        roomRepository.save(room);
+
+        EnterRoom enterRoom = EnterRoom.builder()
+                .room(room)
+                .member(member1)
+                .build();
+        enterRoomRepository.save(enterRoom);
+
+        EnterRoom enterRoom2 = EnterRoom.builder()
+                .room(room)
+                .member(member2)
+                .build();
+        enterRoomRepository.save(enterRoom2);
+
+        EnterRoom enterRoom3 = EnterRoom.builder()
+                .room(room)
+                .member(member3)
+                .build();
+        enterRoomRepository.save(enterRoom3);
+    }
+}

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceThreadTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceThreadTest.java
@@ -1,0 +1,181 @@
+package com.ll.moizatimecalculator.boundedContext.selectedTime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.ll.moizatimecalculator.boundedContext.member.entity.Member;
+import com.ll.moizatimecalculator.boundedContext.member.repository.MemberRepository;
+import com.ll.moizatimecalculator.boundedContext.room.entity.EnterRoom;
+import com.ll.moizatimecalculator.boundedContext.room.entity.Room;
+import com.ll.moizatimecalculator.boundedContext.room.repository.EnterRoomRepository;
+import com.ll.moizatimecalculator.boundedContext.room.repository.RoomRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class RoomTreeMapServiceThreadTest {
+
+    @Autowired
+    RoomTreeMapService roomTreeMapService;
+    @Autowired
+    RoomRepository roomRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EnterRoomRepository enterRoomRepository;
+
+    static Room room;
+    static Member member1;
+    static Member member2;
+    static Member member3;
+
+    @Test
+    @DisplayName("동시성 테스트")
+    @Transactional
+    void multi_thread_test() {
+        final int NUM_USERS = 3;
+        final long ROOM_ID = 1;
+
+        Member[] members = new Member[NUM_USERS + 1];
+
+        for (int i = 1; i < NUM_USERS + 1; i++) {
+            members[i] = memberRepository.findById(Long.valueOf(i)).orElse(new Member());
+        }
+
+        for (int i = 0; i < 10; i++) {
+            ExecutorService executorService = Executors.newFixedThreadPool(NUM_USERS);
+
+            Runnable userTask = () -> {
+                long userId = Thread.currentThread().getId() - 41;
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(0, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(1, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(2, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(3, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(4, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(5, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(6, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(7, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(8, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(9, 0, 0), members[(int) userId]);
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                        LocalTime.of(10, 0, 0), members[(int) userId]);
+            };
+            for (int j = 1; j < NUM_USERS + 1; j++) {
+                executorService.submit(userTask);
+            }
+
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            List<TimeRangeWithMember> overlappingRanges = roomTreeMapService.findOverlappingTimeRanges(
+                    ROOM_ID);
+
+            for (int j = 0; j < 10; j++) {
+                TimeRangeWithMember tm = overlappingRanges.get(j);
+                int finalJ = j;
+                int finalJ1 = j;
+                assertAll(
+                        () -> assertThat(tm.getDate()).isEqualTo(LocalDate.now().plusDays(3)),
+                        () -> assertThat(tm.getStart()).isEqualTo(LocalTime.of(finalJ, 0)),
+                        () -> assertThat(tm.getEnd()).isEqualTo(LocalTime.of(finalJ1 + 3, 0)),
+                        () -> assertThat(tm.getParticipationMembers()).isEqualTo(
+                                List.of(member1, member2, member3))
+                );
+            }
+        }
+
+        List<TimeRangeWithMember> overlappingRanges = roomTreeMapService.findOverlappingTimeRanges(
+                ROOM_ID);
+
+        for (TimeRangeWithMember t : overlappingRanges) {
+            System.out.println(t.date + " | " + t.start + "~" + t.end);
+            System.out.print("참가자 : ");
+            for (Member m : t.getParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+            System.out.print("불참자 : ");
+            for (Member m : t.getNonParticipationMembers()) {
+                System.out.print(m.getName() + " ");
+            }
+            System.out.println();
+        }
+    }
+
+    @BeforeEach
+    void init() {
+        member1 = Member.builder().name("user1").email("user1@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member1);
+        member2 = Member.builder().name("user2").email("user2@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member2);
+        member3 = Member.builder().name("user3").email("user3@email.com").profile(
+                        "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .build();
+        memberRepository.save(member3);
+
+        room = Room.builder()
+                .leader(member1)
+                .name("테스트1")
+                .description("description")
+                .availableStartDay(LocalDate.now().plusDays(5))
+                .availableEndDay(LocalDate.now().plusDays(7))
+                .availableStartTime(LocalTime.of(0, 0))
+                .availableEndTime(LocalTime.of(23, 0))
+                .meetingDuration(LocalTime.of(3, 0))
+                .deadLine(LocalDateTime.now().plusDays(2))
+                .accessCode(UUID.randomUUID().toString())
+                .build();
+        roomRepository.save(room);
+
+        EnterRoom enterRoom = EnterRoom.builder()
+                .room(room)
+                .member(member1)
+                .build();
+        enterRoomRepository.save(enterRoom);
+
+        EnterRoom enterRoom2 = EnterRoom.builder()
+                .room(room)
+                .member(member2)
+                .build();
+        enterRoomRepository.save(enterRoom2);
+
+        EnterRoom enterRoom3 = EnterRoom.builder()
+                .room(room)
+                .member(member3)
+                .build();
+        enterRoomRepository.save(enterRoom3);
+    }
+}

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceThreadTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/RoomTreeMapServiceThreadTest.java
@@ -39,57 +39,57 @@ public class RoomTreeMapServiceThreadTest {
     @Autowired
     EnterRoomRepository enterRoomRepository;
 
-    static Room room;
-    static Member member1;
-    static Member member2;
-    static Member member3;
+    Room room;
+    Member member1;
+    Member member2;
+    Member member3;
 
     @Test
     @DisplayName("동시성 테스트")
     @Transactional
     void multi_thread_test() {
         final int NUM_USERS = 3;
-        final long ROOM_ID = 1;
+
+        final long ROOM_ID = room.getId();
 
         Member[] members = new Member[NUM_USERS + 1];
 
         for (int i = 1; i < NUM_USERS + 1; i++) {
             members[i] = memberRepository.findById(Long.valueOf(i)).orElse(new Member());
+            System.out.println(members[i]);
         }
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 1; i++) {
             ExecutorService executorService = Executors.newFixedThreadPool(NUM_USERS);
 
             Runnable userTask = () -> {
-                long userId = Thread.currentThread().getId() - 41;
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                long userId = Thread.currentThread().getId() - '0' + 1;
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(0, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(1, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(2, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(3, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(4, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(5, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(6, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(7, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(8, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
+                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(6),
                         LocalTime.of(9, 0, 0), members[(int) userId]);
-                roomTreeMapService.setRoomTreeMap(ROOM_ID, LocalDate.now().plusDays(3),
-                        LocalTime.of(10, 0, 0), members[(int) userId]);
             };
-            for (int j = 1; j < NUM_USERS + 1; j++) {
+            for (int j = 0; j < NUM_USERS; j++) {
                 executorService.submit(userTask);
             }
-
             executorService.shutdown();
+
             try {
                 executorService.awaitTermination(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
@@ -98,15 +98,13 @@ public class RoomTreeMapServiceThreadTest {
 
             List<TimeRangeWithMember> overlappingRanges = roomTreeMapService.findOverlappingTimeRanges(
                     ROOM_ID);
-
             for (int j = 0; j < 10; j++) {
                 TimeRangeWithMember tm = overlappingRanges.get(j);
                 int finalJ = j;
-                int finalJ1 = j;
                 assertAll(
-                        () -> assertThat(tm.getDate()).isEqualTo(LocalDate.now().plusDays(3)),
+                        () -> assertThat(tm.getDate()).isEqualTo(LocalDate.now().plusDays(6)),
                         () -> assertThat(tm.getStart()).isEqualTo(LocalTime.of(finalJ, 0)),
-                        () -> assertThat(tm.getEnd()).isEqualTo(LocalTime.of(finalJ1 + 3, 0)),
+                        () -> assertThat(tm.getEnd()).isEqualTo(LocalTime.of(finalJ + 3, 0)),
                         () -> assertThat(tm.getParticipationMembers()).isEqualTo(
                                 List.of(member1, member2, member3))
                 );

--- a/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeServiceTest.java
+++ b/src/test/java/com/ll/moizatimecalculator/boundedContext/selectedTime/service/SelectedTimeServiceTest.java
@@ -49,6 +49,7 @@ class SelectedTimeServiceTest {
 
     @Test
     @DisplayName("현재 + 6일의 _ 겹치는_시간_조회")
+    @Transactional
     void findOverlappingTimeRanges_test() {
 
         List<TimeRangeWithMember> overlappingRanges = selectedTimeService.findOverlappingTimeRanges(
@@ -114,6 +115,7 @@ class SelectedTimeServiceTest {
 
     @Test
     @DisplayName("모임전체_겹치는_시간_조회")
+    @Transactional
     void all_findOverlappingTimeRanges_test() {
 
         List<TimeRangeWithMember> overlappingRanges = selectedTimeService.findOverlappingTimeRanges(
@@ -169,60 +171,6 @@ class SelectedTimeServiceTest {
                 () -> assertThat(t5.getParticipationMembers()).isEqualTo(List.of(member1, member2)),
                 () -> assertThat(t5.getNonParticipationMembers()).isEqualTo(List.of(member3))
                 // 불참자
-        );
-
-    }
-
-    @Test
-    @DisplayName("캐싱 및 중간에 값 변경시 캐시 초기화")
-    void CacheTest() {
-        int firstSecDiffTime = 0;
-        int secondSecDiffTime = 0;
-        int afterCleanCache = 0;
-
-        // 중간에 새로운 값 추가
-        for (int i = 1; i < 6; i++) {
-
-            if (i == 3) {
-                selectedTimeService.refreshCache(room);
-            }
-
-            long beforeTime = System.currentTimeMillis(); // 코드 실행 시작 시간 받아오기
-
-            List<TimeRangeWithMember> overlappingTimeRanges = selectedTimeService.findOverlappingTimeRanges(
-                    room);
-
-            long afterTime = System.currentTimeMillis(); // 코드 실행 후에 시간 받아오기
-            long secDiffTime = (afterTime - beforeTime); //두 시간에 차 계산
-            int sec = (int) (secDiffTime / 1000);
-            int ms = (int) (secDiffTime - sec * 1000);
-            System.out.println("All_findOverlappingTimeRanges 시간 : " + sec + "." + ms + "초");
-
-            TimeRangeWithMember tw = overlappingTimeRanges.get(0);
-            System.out.println(tw.date + "::" + tw.start + "~" + tw.end);
-            for (Member m : tw.participationMembers) {
-                System.out.print(m.getName() + " ");
-            }
-            System.out.println();
-
-            switch (i) {
-                case 1 -> firstSecDiffTime = sec * 1000 + ms;
-                case 2 -> secondSecDiffTime = sec * 1000 + ms;
-                case 3 -> afterCleanCache = sec * 1000 + ms;
-                default -> {
-                }
-            }
-        }
-
-        final int finalFirstSecDiffTime = firstSecDiffTime;
-        final int finalSecondSecDiffTime = secondSecDiffTime;
-        final int finalAfterCleanCache = afterCleanCache;
-
-        assertAll(
-                () -> assertThat(
-                        Long.compare(finalFirstSecDiffTime, finalSecondSecDiffTime)).isEqualTo(1),
-                () -> assertThat(
-                        Long.compare(finalSecondSecDiffTime, finalAfterCleanCache)).isEqualTo(-1)
         );
 
     }


### PR DESCRIPTION
AS-IS
현재 겹치는 시간대를 조회하는 시점에서 계산하는 이유는 중복된 시간이 쌓인 상태로 한 번에 조회하는 것이 효율적이기 때문입니다. 이로 인해 계산과 조회가 한꺼번에 이루어지며, 겹치는 시간대를 쉽게 확인할 수 있습니다.

TO-BE
TreeMap을 사용해, 사용자가 시간을 입력하는 시점에서 정렬하게끔 수정

TreeMap
TreeMap<LocalDateTime, TreeSet> roomTreeMap;
TreeSet 을 사용해 중복 및 오름차순 정렬 적용.
동기화를 위해 데이터 입력, 삭제, 수정 시 synchronized를 적용합니다.

TreeMapService
roomTreeMap은 RoomTreeMapService를 통해서 값을 입력, 삭제, 수정, 최대로 겹치는 시간대를 계산합니다.

Map<Long RoomId, RoomTreeMap> roomDataMap = new ConcurrentHashMap<>();

RoomId를 통해 RoomTreeMap을 가져옵니다. 새로 생성되는 부분(put)에서는 ConcurrentHashMap을 사용해 Thread-safe합니다.

get부분은 최종 업데이트된 값을 가져옵니다.